### PR TITLE
Compiling on Mac OS X

### DIFF
--- a/src/core/ObjectRegistry.hpp
+++ b/src/core/ObjectRegistry.hpp
@@ -2,6 +2,7 @@
 #define OBJECT_REGISTRY_HPP
 
 #include <iterator>
+#include <algorithm>
 
 template <typename Container> class ObjectRegistry {
 public:

--- a/src/core/Vector.hpp
+++ b/src/core/Vector.hpp
@@ -26,6 +26,7 @@
 #include <cmath>
 #include <initializer_list>
 #include <iterator>
+#include <vector>
 
 #include <boost/serialization/array.hpp>
 

--- a/src/core/constraints/CMakeLists.txt
+++ b/src/core/constraints/CMakeLists.txt
@@ -1,4 +1,4 @@
 file(GLOB Constraints_SRC Constraint.cpp)
 add_library(Constraints SHARED ${Constraints_SRC})
 add_dependencies(Constraints EspressoConfig)
-
+set_target_properties(Constraints PROPERTIES MACOSX_RPATH TRUE)

--- a/src/core/correlators/CMakeLists.txt
+++ b/src/core/correlators/CMakeLists.txt
@@ -1,4 +1,4 @@
 file(GLOB Correlators_SRC *.?pp)
 add_library(Correlators SHARED ${Correlators_SRC})
 add_dependencies(Correlators EspressoConfig)
-
+set_target_properties(Correlators PROPERTIES MACOSX_RPATH TRUE)

--- a/src/core/lbboundaries/CMakeLists.txt
+++ b/src/core/lbboundaries/CMakeLists.txt
@@ -1,4 +1,4 @@
 file(GLOB LBBoundaries_SRC LBBoundary.cpp)
 add_library(LBBoundaries SHARED ${LBBoundaries_SRC})
 add_dependencies(LBBoundaries EspressoConfig)
-
+set_target_properties(LBBoundaries PROPERTIES MACOSX_RPATH TRUE)

--- a/src/core/observables/CMakeLists.txt
+++ b/src/core/observables/CMakeLists.txt
@@ -1,4 +1,4 @@
 file(GLOB Observables_SRC *.?pp)
 add_library(Observables SHARED ${Observables_SRC})
 add_dependencies(Observables EspressoConfig)
-
+set_target_properties(Observables PROPERTIES MACOSX_RPATH TRUE)

--- a/src/core/shapes/CMakeLists.txt
+++ b/src/core/shapes/CMakeLists.txt
@@ -1,3 +1,4 @@
 file(GLOB Shapes_SRC *.cpp)
 add_library(Shapes SHARED ${Shapes_SRC})
 add_dependencies(Shapes EspressoConfig)
+set_target_properties(Shapes PROPERTIES MACOSX_RPATH TRUE)

--- a/src/core/utils/CMakeLists.txt
+++ b/src/core/utils/CMakeLists.txt
@@ -1,2 +1,3 @@
 file(GLOB EspressoUtils_SRC *.cpp)
 add_library(EspressoUtils SHARED ${EspressoUtils_SRC})
+set_target_properties(EspressoUtils PROPERTIES MACOSX_RPATH TRUE)

--- a/src/script_interface/CMakeLists.txt
+++ b/src/script_interface/CMakeLists.txt
@@ -4,6 +4,7 @@ file(GLOB_RECURSE EspressoScriptInterface_SRC
 
 add_library(EspressoScriptInterface SHARED ${EspressoScriptInterface_SRC})
 add_dependencies(EspressoScriptInterface EspressoConfig EspressoConfig)
+set_target_properties(EspressoScriptInterface PROPERTIES MACOSX_RPATH TRUE)
 target_link_libraries(EspressoScriptInterface EspressoCore)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
Fix some minor issues to get Espresso to compile with the myconfig file you sent by email.
There is a bunch of warnings related to inheritance (missing `override` keywords, missing `return` statements in `virtual` functions in the base class, ...), but no critical ones as far as I saw.

I still can't run the python code because the symbol `ScriptInterface::Constraints::initialize()` is unresolved. Also, I can't compile with `LB` enabled, but that appears to be broken at the moment?
