### PR TITLE
lb tut: fixed excapes and removed tcl script ref

### DIFF
--- a/doc/tutorials/python/04-lattice_boltzmann/latex/diffusion.tex
+++ b/doc/tutorials/python/04-lattice_boltzmann/latex/diffusion.tex
@@ -68,7 +68,7 @@ The script takes the LB-friction coefficient as an argument. Start with
 an friction coefficient of 1.0:
 {\vspace{0,2cm}\small
 \begin{lstlisting}[numbers=none]
-/path/to/pypresso single\_particle\_diffusion.py 1.0
+/path/to/pypresso single_particle_diffusion.py 1.0
 \end{lstlisting}
 \vspace{0,2cm}
 }
@@ -131,7 +131,7 @@ adjacent beads to hold the polymer together. You have already learned
 that the command
 {\vspace{0,2cm}\small
 \begin{pypresso}
-  s.non\_bonded\_inter[0,0].lennard\_jones.set\_params(
+  s.non_bonded_inter[0,0].lennard_jones.set_params(
       epsilon = 1.0, sigma = 1.0,
       shift = 0.25, cutof = 1.226)
 \end{pypresso}\vspace{0,2cm}
@@ -143,7 +143,7 @@ repulsive interaction. The command
 {\vspace{0,2cm}\small
 \begin{pypresso}
   from espressomd import interactions
-  fene = interactions.FeneBond(k = 7,d\_r\_max = 2)
+  fene = interactions.FeneBond(k = 7,d_r_max = 2)
 \end{pypresso}
 \vspace{0,2cm}
 }
@@ -160,8 +160,8 @@ fixed distance between adjacent bead positions. The syntax is:
   from espressomd import polymer
   # mpc: monomers per chain
   mpc = 30
-  poly = system.polymer(N\_P=1, MPC = mpc, bond\_id=fene.\_bond\_id,
-                        bond\_length = 1)
+  poly = system.polymer(N_P=1, MPC = mpc, bond_id=fene._bond_id,
+                        bond_length = 1)
 \end{pypresso}
 \vspace{0,2cm}
 }
@@ -180,7 +180,7 @@ are possible. You can probably make it shorter.
 It is called in the following way:
 {\vspace{0,2cm}\small
 \begin{lstlisting}[numbers=none]
-/path/to/pypresso polymer\_diffusion.py \$N\_monomers  
+/path/to/pypresso polymer_diffusion.py $N_monomers  
 \end{lstlisting}\vspace{0,2cm}
 }
 This allows to quickly change the number of monomers without editing 

--- a/doc/tutorials/python/04-lattice_boltzmann/latex/interface.tex
+++ b/doc/tutorials/python/04-lattice_boltzmann/latex/interface.tex
@@ -69,9 +69,9 @@ example.
 
   # initialize the System and set the necessary MD parameters for LB.
   s = system.System()
-  s.box\_l = [31, 41, 59]
-  s.time\_step = 0.01
-  s.cell\_system.skin = 0.4
+  s.box_l = [31, 41, 59]
+  s.time_step = 0.01
+  s.cell_system.skin = 0.4
 
   # Initialize and LBFluid with the minimum set of valid parameters.
   lbf = lb.LBFluid(agrid = 1, dens = 10, visc = .1, tau = 0.01)
@@ -86,7 +86,7 @@ The \texttt{LBFluid} class also provides a set of methods which can be used to
 sample data from the fluid nodes. For example 
 \vspace{0,2cm}
 \begin{pypresso}
-  lbf.lbnode\_get\_node\_xxxx([X,Y,Z])
+  lbf.lbnode_get_node_xxxx([X,Y,Z])
 \end{pypresso}
 \vspace{0,2cm}
 returns the propert xxxx of the node with $(X,Y,Z)$ coordinates. Note that the

--- a/doc/tutorials/python/04-lattice_boltzmann/latex/poiseuille.tex
+++ b/doc/tutorials/python/04-lattice_boltzmann/latex/poiseuille.tex
@@ -153,7 +153,7 @@ so that $u_y=0$ at $z = \pm l/2$ and we obtain:
 \begin{equation}
   u_y = \frac{f}{2\eta} \left(l^2/4-x^2\right)
 \end{equation}
-With that knowledge investigate the script \texttt{poisseuille.tcl}.
+With that knowledge investigate the script \texttt{poisseuille.py}.
 Note the use of the \texttt{lbboundaries} module. Two walls are created
 with normal vectors $\left(\pm 1, 0, 0 \right)$. An external force
 is applied to every node. After 5000 LB updates the steady state should


### PR DESCRIPTION
- removed escapes in pypresso and lstlisting float.
- removed last mention of a tcl script 
