### PR TITLE
Fix LB coupling for VirtualSitesInertialessTracers.

### DIFF
--- a/src/core/grid_based_algorithms/lb_particle_coupling.cpp
+++ b/src/core/grid_based_algorithms/lb_particle_coupling.cpp
@@ -40,7 +40,6 @@
 #include <cmath>
 #include <cstddef>
 #include <stdexcept>
-#include <unordered_set>
 #include <utility>
 
 LB_Particle_Coupling lb_particle_coupling;

--- a/src/core/grid_based_algorithms/lb_particle_coupling.hpp
+++ b/src/core/grid_based_algorithms/lb_particle_coupling.hpp
@@ -31,6 +31,7 @@
 #include <boost/serialization/optional.hpp>
 
 #include <cstdint>
+#include <unordered_set>
 #include <vector>
 
 using OptionalCounter = boost::optional<Utils::Counter<uint64_t>>;
@@ -73,6 +74,14 @@ void lb_lbcoupling_deactivate();
  * @return True iff the point is inside of the domain.
  */
 bool in_local_halo(Utils::Vector3d const &pos);
+
+/** @brief Determine if a given particle should be coupled.
+ *  In certain cases, there may be more than one ghost for the same particle.
+ *  To make sure, that these are only coupled once, ghosts' ids are stored
+ *  in an unordered_set.
+ */
+bool should_be_coupled(const Particle &p,
+                       std::unordered_set<int> &coupled_ghost_particles);
 
 /**
  * @brief Add a force to the lattice force density.

--- a/testsuite/python/CMakeLists.txt
+++ b/testsuite/python/CMakeLists.txt
@@ -175,8 +175,8 @@ python_test(FILE lb_lees_edwards_particle_coupling.py MAX_NUM_PROC 1)
 python_test(FILE lb_planar_couette.py MAX_NUM_PROC 1)
 python_test(FILE nsquare.py MAX_NUM_PROC 4)
 python_test(FILE virtual_sites_relative.py MAX_NUM_PROC 2)
-# python_test(FILE virtual_sites_tracers_walberla.py MAX_NUM_PROC 1
-#             DEPENDENCIES virtual_sites_tracers_common.py) # TODO WALBERLA: fails since #4470
+python_test(FILE virtual_sites_tracers_walberla.py MAX_NUM_PROC 2
+            DEPENDENCIES virtual_sites_tracers_common.py)
 python_test(FILE regular_decomposition.py MAX_NUM_PROC 4)
 python_test(FILE integrator_npt.py MAX_NUM_PROC 4)
 python_test(FILE integrator_npt_stats.py MAX_NUM_PROC 4 LABELS long)


### PR DESCRIPTION
Fixes #3515

Test passes with 1 and 2 cores, should also work with more cores, howerver, as @jngrad told me, 4 cores are currently an issue with walberla due to different partitioning of the simulation box in espresso and walberla, respectively.