### PR TITLE
renaming the viscocity to kinematic viscosity

### DIFF
--- a/src/python/espressomd/lb.py
+++ b/src/python/espressomd/lb.py
@@ -54,7 +54,7 @@ class HydrodynamicInteraction(ScriptInterfaceHelper):
         LB time step, must be an integer multiple of the MD time step.
     density : :obj:`float`
         Fluid density.
-    viscosity : :obj:`float`
+    kinematic_viscosity : :obj:`float`
         Fluid kinematic viscosity.
     ext_force_density : (3,) array_like of :obj:`float`, optional
         Force density applied on the fluid.
@@ -96,7 +96,7 @@ class HydrodynamicInteraction(ScriptInterfaceHelper):
         return self._params
 
     def validate_params(self, params):
-        for key in ('agrid', 'tau', 'density', 'viscosity'):
+        for key in ('agrid', 'tau', 'density', 'kinematic_viscosity'):
             if key not in params or key not in self.valid_keys():
                 continue
             utils.check_type_or_throw_except(
@@ -116,11 +116,11 @@ class HydrodynamicInteraction(ScriptInterfaceHelper):
             params['ext_force_density'], 3, float, 'ext_force_density must be 3 floats')
 
     def valid_keys(self):
-        return {"agrid", "tau", "density", "ext_force_density", "viscosity",
+        return {"agrid", "tau", "density", "ext_force_density", "kinematic_viscosity",
                 "lattice", "kT", "seed"}
 
     def required_keys(self):
-        return {"lattice", "density", "viscosity", "tau"}
+        return {"lattice", "density", "kinematic_viscosity", "tau"}
 
     def default_params(self):
         return {"lattice": None, "seed": 0, "kT": 0.,
@@ -168,7 +168,7 @@ class HydrodynamicInteraction(ScriptInterfaceHelper):
         self._params['kT'] = self.kT
         if self._params['kT'] > 0.0:
             self._params['seed'] = self.seed
-        self._params['viscosity'] = self.viscosity
+        self._params['kinematic_viscosity'] = self.kinematic_viscosity
         self._params['ext_force_density'] = self.ext_force_density
 
         return self._params

--- a/src/script_interface/walberla/FluidWalberla.hpp
+++ b/src/script_interface/walberla/FluidWalberla.hpp
@@ -90,7 +90,7 @@ public:
          [this]() { return static_cast<int>(m_lb_fluid->get_rng_state()); }},
         {"density", AutoParameter::read_only,
          [this]() { return m_lb_fluid->get_density() / m_conv_dens; }},
-        {"viscosity",
+        {"kinematic_viscosity",
          [this](const Variant &v) {
            auto const visc = m_conv_visc * get_value<double>(v);
            m_lb_fluid->set_viscosity(visc);
@@ -124,7 +124,7 @@ public:
     m_is_active = false;
     m_seed = get_value<int>(params, "seed");
     auto const lb_lattice = lb_lattice_si->lattice();
-    auto const lb_visc = m_conv_visc * get_value<double>(params, "viscosity");
+    auto const lb_visc = m_conv_visc * get_value<double>(params, "kinematic_viscosity");
     auto const lb_dens = m_conv_dens * get_value<double>(params, "density");
     auto const lb_temp = m_conv_temp * get_value<double>(params, "kT");
     auto const ext_f = m_conv_force_dens *

--- a/testsuite/python/engine_lb.py
+++ b/testsuite/python/engine_lb.py
@@ -31,7 +31,7 @@ class SwimmerTest():
     system.time_step = 1e-2
     LB_params = {'agrid': 1,
                  'density': 1.1,
-                 'viscosity': 1.2,
+                 'kinematic_viscosity': 1.2,
                  'kT': 0,
                  'tau': system.time_step}
     gamma = 0.3

--- a/testsuite/python/lb.py
+++ b/testsuite/python/lb.py
@@ -48,7 +48,7 @@ class LBTest:
     params = {'tau': 0.01,
               'agrid': 0.5,
               'density': 0.85,
-              'viscosity': 3.0}
+              'kinematic_viscosity': 3.0}
 
     system.periodicity = [True, True, True]
     system.time_step = params['tau']
@@ -89,7 +89,7 @@ class LBTest:
         # check LB object
         self.assertAlmostEqual(lbf.tau, tau, delta=self.atol)
         self.assertAlmostEqual(lbf.agrid, agrid, delta=self.atol)
-        self.assertAlmostEqual(lbf.viscosity, 3., delta=self.atol)
+        self.assertAlmostEqual(lbf.kinematic_viscosity, 3., delta=self.atol)
         self.assertAlmostEqual(lbf.density, 0.85, delta=self.atol)
         self.assertAlmostEqual(lbf.kT, 1.0, delta=self.atol)
         self.assertEqual(lbf.seed, 42)
@@ -98,8 +98,8 @@ class LBTest:
             self.lb_params['single_precision'])
         np.testing.assert_allclose(
             np.copy(lbf.ext_force_density), [0., 0., 0.], atol=self.atol)
-        lbf.viscosity = 2.
-        self.assertAlmostEqual(lbf.viscosity, 2., delta=self.atol)
+        lbf.kinematic_viscosity = 2.
+        self.assertAlmostEqual(lbf.kinematic_viscosity, 2., delta=self.atol)
         ext_f = [0.01, 0.02, 0.03]
         lbf.ext_force_density = ext_f
         np.testing.assert_allclose(
@@ -117,8 +117,8 @@ class LBTest:
         self.assertEqual(
             lbf.is_single_precision,
             self.lb_params['single_precision'])
-        lbf.viscosity = 3.
-        self.assertAlmostEqual(lbf.viscosity, 3., delta=self.atol)
+        lbf.kinematic_viscosity = 3.
+        self.assertAlmostEqual(lbf.kinematic_viscosity, 3., delta=self.atol)
         ext_force_density = [0.02, 0.05, 0.07]
         lbf.ext_force_density = ext_force_density
         np.testing.assert_allclose(np.copy(lbf.ext_force_density),
@@ -329,7 +329,7 @@ class LBTest:
         lj_sig = 1.0
         l = (n_part * 4. / 3. * np.pi * (lj_sig / 2.)**3 / phi)**(1. / 3.)
         system.box_l = [l] * 3 * np.array(system.cell_system.node_grid)
-        lbf = self.lb_class(agrid=l / 31, density=1, viscosity=1, kT=0,
+        lbf = self.lb_class(agrid=l / 31, density=1, kinematic_viscosity=1, kT=0,
                             tau=system.time_step, **self.lb_params)
         system.actors.add(lbf)
         system.integrator.run(steps=1)
@@ -532,7 +532,7 @@ class LBTest:
         base_params = {}
         base_params.update(
             ext_force_density=[2.3, 1.2, 0.1],
-            viscosity=self.params['viscosity'],
+            kinematic_viscosity=self.params['kinematic_viscosity'],
             density=self.params['density'],
             agrid=self.params['agrid'])
 

--- a/testsuite/python/lb_boundary_velocity.py
+++ b/testsuite/python/lb_boundary_velocity.py
@@ -33,7 +33,7 @@ class LBBoundaryVelocityTest(ut.TestCase):
 
     lb_params = {'agrid': 0.6,
                  'density': 0.5,
-                 'viscosity': 3.2,
+                 'kinematic_viscosity': 3.2,
                  'tau': 0.7}
     system = espressomd.System(box_l=3 * [8 * lb_params['agrid']])
     system.time_step = lb_params['tau']

--- a/testsuite/python/lb_boundary_volume_force.py
+++ b/testsuite/python/lb_boundary_volume_force.py
@@ -31,7 +31,7 @@ DENS = 1.5
 TIME_STEP = 0.05
 LB_PARAMS = {'agrid': AGRID,
              'density': DENS,
-             'viscosity': VISC,
+             'kinematic_viscosity': VISC,
              'tau': TIME_STEP,
              'ext_force_density': EXT_FORCE}
 

--- a/testsuite/python/lb_buoyancy_force.py
+++ b/testsuite/python/lb_buoyancy_force.py
@@ -33,7 +33,7 @@ BOX_SIZE = 18 * AGRID
 
 LB_PARAMS = {'agrid': AGRID,
              'density': DENS,
-             'viscosity': KVISC,
+             'kinematic_viscosity': KVISC,
              'tau': TIME_STEP,
              'ext_force_density': [0, DENS * G, 0]}
 # System setup

--- a/testsuite/python/lb_density.py
+++ b/testsuite/python/lb_density.py
@@ -31,7 +31,7 @@ DENS = 1.7
 TIME_STEP = 0.01
 LB_PARAMS = {'agrid': AGRID,
              'density': DENS,
-             'viscosity': VISC,
+             'kinematic_viscosity': VISC,
              'tau': TIME_STEP,
              'kT': KT,
              'seed': 23}

--- a/testsuite/python/lb_electrohydrodynamics.py
+++ b/testsuite/python/lb_electrohydrodynamics.py
@@ -34,7 +34,7 @@ class LBEHTest(ut.TestCase):
                        'tau': 0.02,
                        'agrid': 0.5,
                        'dens': 0.85,
-                       'viscosity': 30.0,
+                       'kinematic_viscosity': 30.0,
                        'friction': 3.0,
                        'temp': 0.0,
                        'skin': 0.2,
@@ -45,7 +45,7 @@ class LBEHTest(ut.TestCase):
         system.cell_system.skin = self.params['skin']
 
         lbf = espressomd.lb.LBFluidWalberla(
-            viscosity=self.params['viscosity'],
+            kinematic_viscosity=self.params['kinematic_viscosity'],
             density=self.params['dens'],
             agrid=self.params['agrid'],
             tau=system.time_step,

--- a/testsuite/python/lb_interpolation.py
+++ b/testsuite/python/lb_interpolation.py
@@ -35,7 +35,7 @@ BOX_L = 18.0
 TIME_STEP = TAU
 LB_PARAMETERS = {
     'agrid': AGRID,
-    'viscosity': VISC,
+    'kinematic_viscosity': VISC,
     'density': DENS,
     'tau': TAU
 }

--- a/testsuite/python/lb_momentum_conservation.py
+++ b/testsuite/python/lb_momentum_conservation.py
@@ -35,7 +35,7 @@ GAMMA = 1
 
 LB_PARAMS = {'agrid': AGRID,
              'density': DENS,
-             'viscosity': KVISC,
+             'kinematic_viscosity': KVISC,
              'tau': TIME_STEP,
              'ext_force_density': np.array([-.7 * F, .9 * F, .8 * F])}
 

--- a/testsuite/python/lb_planar_couette.py
+++ b/testsuite/python/lb_planar_couette.py
@@ -36,7 +36,7 @@ def analytical(x, t, nu, v, h, k_max):
     t : :obj:`float`
         Time since the start up of the shear flow
     nu: :obj:`float`
-        Kinematic viscosity
+        Kinematic kinematic_viscosity
     v: :obj:`float`
         Shearing velocity
     h : :obj:`float`
@@ -53,7 +53,7 @@ def analytical(x, t, nu, v, h, k_max):
 
 LB_PARAMS = {'agrid': 1.,
              'density': 1.,
-             'viscosity': 1. / 6.,
+             'kinematic_viscosity': 1. / 6.,
              'tau': 1.}
 
 
@@ -98,7 +98,7 @@ class LBCouetteFlowCommon:
             steps = (2**i - 2**(i - 1))
             system.integrator.run(steps)
             pos = np.linspace(0.5, 63.5, 64)
-            u_ref = analytical(pos, system.time - 1., lbf.viscosity,
+            u_ref = analytical(pos, system.time - 1., lbf.kinematic_viscosity,
                                shear_velocity, h, k_max)
             u_lbf = np.copy(u_getter(lbf).reshape([-1]))
             np.testing.assert_allclose(u_lbf, u_ref, atol=1e-4, rtol=0.)

--- a/testsuite/python/lb_poiseuille.py
+++ b/testsuite/python/lb_poiseuille.py
@@ -26,12 +26,12 @@ import espressomd.shapes
 
 AGRID = .25
 EXT_FORCE = .1
-VISC = 2.7
+KINEMATIC_VISC = 2.7
 DENS = 1.7
 TIME_STEP = 0.07
 LB_PARAMS = {'agrid': AGRID,
              'density': DENS,
-             'viscosity': VISC,
+             'kinematic_viscosity':KINEMATIC_VISC,
              'tau': TIME_STEP,
              'ext_force_density': [0.0, 0.0, EXT_FORCE]}
 
@@ -115,7 +115,7 @@ class LBPoiseuilleCommon:
         v_expected = poiseuille_flow(velocities[1:-1, 0] - 0.5 * self.system.box_l[0],
                                      self.system.box_l[0] - 2.0 * AGRID,
                                      EXT_FORCE,
-                                     VISC * DENS)
+                                     KINEMATIC_VISC * DENS)
         np.testing.assert_allclose(v_measured, v_expected, rtol=5E-5)
 
 

--- a/testsuite/python/lb_poiseuille_cylinder.py
+++ b/testsuite/python/lb_poiseuille_cylinder.py
@@ -28,14 +28,14 @@ import espressomd.shapes
 
 AGRID = .5
 EXT_FORCE = .1
-VISC = 2.7
+KINEMATIC_VISC = 2.7
 DENS = 1.7
 TIME_STEP = 0.05
 BOX_L = 8.0
 EFFECTIVE_RADIUS = BOX_L / 2.0 - 1.0
 LB_PARAMS = {'agrid': AGRID,
              'density': DENS,
-             'viscosity': VISC,
+             'kinematic_viscosity':KINEMATIC_VISC,
              'tau': TIME_STEP}
 
 OBS_PARAMS = {'n_r_bins': 6,
@@ -140,7 +140,7 @@ class LBPoiseuilleCommon:
             positions[1:-1] - BOX_L / 2.0,
             EFFECTIVE_RADIUS,
             EXT_FORCE,
-            VISC * DENS)
+            KINEMATIC_VISC * DENS)
         f_half_correction = 0.5 * self.system.time_step * EXT_FORCE * AGRID**3 / DENS
         np.testing.assert_allclose(v_measured + f_half_correction,
                                    v_expected, atol=0.01, rtol=0.)
@@ -167,7 +167,7 @@ class LBPoiseuilleCommon:
             r,
             EFFECTIVE_RADIUS,
             EXT_FORCE,
-            VISC * DENS)
+            KINEMATIC_VISC * DENS)
         v_r, v_phi, v_z = np.copy(obs.calculate()).reshape([-1, 3]).T
         # check velocity is zero for the radial and azimuthal components
         np.testing.assert_allclose(v_r, 0., atol=1e-4, rtol=0.)

--- a/testsuite/python/lb_shear.py
+++ b/testsuite/python/lb_shear.py
@@ -37,7 +37,7 @@ SHEAR_VELOCITY = 0.3
 
 LB_PARAMS = {'agrid': AGRID,
              'density': DENS,
-             'viscosity': VISC,
+             'kinematic_viscosity': VISC,
              'tau': TIME_STEP
              }
 
@@ -53,7 +53,7 @@ def shear_flow(x, t, nu, v, h, k_max):
     t : :obj:`float`
         Time since start of the shearing.
     nu : :obj:`float`
-        Kinematic viscosity.
+        Kinematic kinematic_viscosity.
     v : :obj:`float`
         Shear rate.
     h : :obj:`float`
@@ -147,13 +147,13 @@ class LBShearCommon:
         # https://de.wikipedia.org/wiki/Navier-Stokes-Gleichungen
         # note that for an incompressible fluid the viscous stress tensor is
         # defined as \sigma = -p 1 + \mu [\nabla * u + (\nabla * u)^T]
-        # where 'p' is the static pressure, '\mu' is the dynamic viscosity,
+        # where 'p' is the static pressure, '\mu' is the dynamic kinematic_viscosity,
         # '*' denotes the outer product and 'u' is the velocity field
         # NOTE: the so called stress property of the fluid is actually the
         # pressure tensor not the viscous stress tensor!
         shear_rate = SHEAR_VELOCITY / H
-        dynamic_viscosity = self.lbf.viscosity * DENS
-        p_expected = p_eq * np.identity(3) - dynamic_viscosity * shear_rate * (
+        dynamic_kinematic_viscosity = self.lbf.kinematic_viscosity * DENS
+        p_expected = p_eq * np.identity(3) - dynamic_kinematic_viscosity * shear_rate * (
             np.outer(shear_plane_normal, shear_direction) + np.transpose(np.outer(shear_plane_normal, shear_direction)))
         # Walberla TODO
         for n in []:  # (2, 3, 4), (3, 4, 2), (5, 4, 3):
@@ -168,7 +168,7 @@ class LBShearCommon:
 #            -np.copy(wall2.get_force()),
 #            atol=1E-4)
 #        np.testing.assert_allclose(np.dot(np.copy(wall1.get_force()), shear_direction),
-# SHEAR_VELOCITY / H * W**2 * dynamic_viscosity, atol=2E-4)
+# SHEAR_VELOCITY / H * W**2 * dynamic_kinematic_viscosity, atol=2E-4)
 
     def test(self):
         x = np.array((1, 0, 0), dtype=int)

--- a/testsuite/python/lb_stats.py
+++ b/testsuite/python/lb_stats.py
@@ -36,7 +36,7 @@ class TestLB:
     params = {'tau': 0.01,
               'agrid': 0.5,
               'dens': 0.85,
-              'viscosity': 3.0,
+              'kinematic_viscosity': 3.0,
               'friction': 2.0,
               'temp': 1.5,
               'gamma': 1.5}
@@ -65,7 +65,7 @@ class TestLB:
 
         self.lbf = self.lb_class(
             kT=self.params['temp'],
-            viscosity=self.params['viscosity'],
+            kinematic_viscosity=self.params['kinematic_viscosity'],
             density=self.params['dens'],
             agrid=self.params['agrid'],
             tau=self.system.time_step,

--- a/testsuite/python/lb_stokes_sphere.py
+++ b/testsuite/python/lb_stokes_sphere.py
@@ -30,7 +30,7 @@ KVISC = 6
 DENS = 2.3
 LB_PARAMS = {'agrid': AGRID,
              'density': DENS,
-             'viscosity': KVISC,
+             'kinematic_viscosity': KVISC,
              'tau': TIME_STEP}
 # System setup
 radius = 7 * AGRID

--- a/testsuite/python/lb_streaming.py
+++ b/testsuite/python/lb_streaming.py
@@ -77,7 +77,7 @@ REFERENCE_POPULATIONS = np.array([
     17 + 2 / 3])
 LB_PARAMETERS = {
     'agrid': AGRID,
-    'viscosity': VISC,
+    'kinematic_viscosity': VISC,
     'tau': TAU,
     'density': 1.0,
 }

--- a/testsuite/python/lb_thermostat.py
+++ b/testsuite/python/lb_thermostat.py
@@ -38,7 +38,7 @@ TIME_STEP = 0.005
 GAMMA = 2
 LB_PARAMS = {'agrid': AGRID,
              'density': DENS,
-             'viscosity': VISC,
+             'kinematic_viscosity': VISC,
              'tau': TIME_STEP,
              'kT': KT,
              'seed': 123}

--- a/testsuite/python/linear_momentum_lb.py
+++ b/testsuite/python/linear_momentum_lb.py
@@ -36,7 +36,7 @@ BOX_L = 3.0
 
 LB_PARAMS = {'agrid': AGRID,
              'density': DENS,
-             'viscosity': VISC,
+             'kinematic_viscosity': VISC,
              'tau': TIME_STEP,
              'ext_force_density': [0.1, 0.2, 0.3]}
 

--- a/testsuite/python/observable_cylindricalLB.py
+++ b/testsuite/python/observable_cylindricalLB.py
@@ -39,7 +39,7 @@ class CylindricalLBObservableCommon:
 
     lb_params = {'agrid': 1.,
                  'density': 1.2,
-                 'viscosity': 2.7,
+                 'kinematic_viscosity': 2.7,
                  'tau': 0.1,
                  }
     cyl_transform_params = espressomd.math.CylindricalTransformationParameters(

--- a/testsuite/python/observable_profileLB.py
+++ b/testsuite/python/observable_profileLB.py
@@ -41,7 +41,7 @@ VISC = .7
 DENS = 1.7
 LB_PARAMS = {'agrid': AGRID,
              'density': DENS,
-             'viscosity': VISC,
+             'kinematic_viscosity': VISC,
              'tau': TIME_STEP
              }
 

--- a/testsuite/python/test_checkpoint.py
+++ b/testsuite/python/test_checkpoint.py
@@ -134,7 +134,7 @@ class CheckpointTest(ut.TestCase):
         state = lbf.get_params()
         reference = {
             "agrid": 2.0,
-            "viscosity": 1.3,
+            "kinematic_viscosity": 1.3,
             "density": 1.5,
             "tau": 0.01}
         for key in reference:
@@ -600,7 +600,7 @@ class CheckpointTest(ut.TestCase):
             integ['integrator'],
             espressomd.integrate.StokesianDynamics)
         expected_params = {
-            'approximation_method': 'ft', 'radii': {0: 1.5}, 'viscosity': 0.5,
+            'approximation_method': 'ft', 'radii': {0: 1.5}, 'kinematic_viscosity': 0.5,
             'lubrication': False, 'pair_mobility': False, 'self_mobility': True}
         params = integ['integrator'].get_params()
         self.assertEqual(params, expected_params)


### PR DESCRIPTION
# Fixes made

Changes have been made from 'viscosity' to 'kinematic_viscosity' in the following places : 
- src/python/espressomd/lb.py
- src/script_interface/walberla/FluidWalberla.hpp
- testsuite/python/*

Remaining places where changes need to be made are:
- User's guide
- doc/tutorials